### PR TITLE
Create docs if the dir does not exist

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -88,6 +88,9 @@ build_dir=/tmp/sphinxnotes-pages
 mkdir -p $build_dir || true
 echo Temp directory \"$build_dir\" is created
 
+echo ::group:: Creating doc dir
+mkdir -p "$doc_dir"
+
 echo ::group:: Running Sphinx builder
 if ! sphinx-build -b html $INPUT_SPHINX_BUILD_OPTIONS "$doc_dir" "$build_dir"; then
     # See: https://github.com/sphinx-notes/pages/issues/28


### PR DESCRIPTION
I got an error if the docs folder is not there. So I added a line to create it if it does not exist.  
I did not know how to test it, so please do so before accepting the pull request.