### PR TITLE
Update README.rst (use ubuntu-latest)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Publishing with this action (default)
 
       jobs:
         pages:
-          runs-on: ubuntu-20.04
+          runs-on: ubuntu-latest
           environment:
             name: github-pages
             url: ${{ steps.deployment.outputs.page_url }}
@@ -60,7 +60,7 @@ Publishing from a branch (classical)
 
       jobs:
         pages:
-          runs-on: ubuntu-20.04
+          runs-on: ubuntu-latest
           steps:
           - id: deployment
             uses: sphinx-notes/pages@v3


### PR DESCRIPTION
Ubuntu 20 is soon to be [removed completely from runners](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/)

I've just [tested unbutu-latest with our docs](https://github.com/zk-org/zk/actions/runs/13376734442), and it runs fine. Not much of a robust test. But... It works on our end.


