### PR TITLE
Support uv as an optional, faster installer (with CI tests)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [v3]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        installer: [pip, uv]
+        cache: [false, true]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # Required by sphinxnotes-incrbuild when cache is enabled
+      - id: build
+        name: Build documentation (installer=${{ matrix.installer }}, cache=${{ matrix.cache }})
+        uses: ./
+        with:
+          installer: ${{ matrix.installer }}
+          cache: ${{ matrix.cache }}
+          checkout: false
+          publish: false
+      - name: Verify build output
+        run: test -f "${{ steps.build.outputs.artifact }}/index.html"

--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,8 @@ Unless you need to highly customize the action's behavior.
 Input                      Default                      Required Description
 -------------------------- ---------------------------- -------- -------------------------------------------------
 ``python_version``         ``3.12``                     false    Version of Python
+``installer``              ``pip``                      false    Python package installer used to install
+                                                                 dependencies, ``pip`` or ``uv``
 ``sphinx_version``         ``latest``                   false    Version of Sphinx
 ``sphinx_build_options``                                false    Additional options passed to ``sphinx-build``
 ``cache``                  ``false``                    false    Enable cache to speed up documentation building
@@ -206,6 +208,21 @@ For non-python dependencies, add a step to your workflow file, and install them 
 (such as apt, wget, ...). See `#24`__ for example.
 
 __ https://github.com/sphinx-notes/pages/issues/24
+
+Speed up installation with uv
+*****************************
+
+Dependencies are installed with pip by default. Set the ``installer`` input to ``uv``
+to install them with uv__ instead, which is usually much faster:
+
+.. code:: yaml
+
+   - id: deployment
+     uses: sphinx-notes/pages@v3
+     with:
+       installer: uv
+
+__ https://github.com/astral-sh/uv
 
 Customize checkout options
 **************************

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: 'Version of Python'
     required: false
     default: '3.12'
+  installer:
+    description: 'Python package installer used to install dependencies, "pip" or "uv"'
+    required: false
+    default: 'pip'
   sphinx_version:
     description: 'Version of Sphinx'
     required: false
@@ -68,15 +72,22 @@ runs:
 
     - name: Setup python
       uses: actions/setup-python@v6
-      if: ${{ inputs.cache == 'true' }}
+      if: ${{ inputs.cache == 'true' && inputs.installer == 'pip' }}
       with:
         python-version: ${{ inputs.python_version }}
         cache: 'pip'
     - name: Setup python
       uses: actions/setup-python@v6
-      if: ${{ inputs.cache == 'false' }}
+      if: ${{ inputs.cache == 'false' || inputs.installer == 'uv' }}
       with:
         python-version: ${{ inputs.python_version }}
+
+    - name: Setup uv
+      # setup-uv only publishes exact version tags, no major tags like v9
+      uses: astral-sh/setup-uv@v9.0.0
+      if: ${{ inputs.installer == 'uv' }}
+      with:
+        enable-cache: ${{ inputs.cache }}
 
     - name: Restore cache
       uses: actions/cache@v5
@@ -101,6 +112,7 @@ runs:
         INPUT_REQUIREMENTS_PATH: ${{ inputs.requirements_path }}
         INPUT_PYPROJECT_EXTRAS: ${{ inputs.pyproject_extras }}
         INPUT_PYPROJECT_GROUP: ${{ inputs.pyproject_group }}
+        INPUT_INSTALLER: ${{ inputs.installer }}
         INPUT_SPHINX_VERSION: ${{ inputs.sphinx_version }}
         INPUT_CACHE: ${{ inputs.cache }}
         INPUT_SPHINX_BUILD_OPTIONS: ${{ inputs.sphinx_build_options }}

--- a/main.sh
+++ b/main.sh
@@ -17,15 +17,30 @@ echo Documentation: $doc_dir
 
 echo ::endgroup::
 
+if [ "$INPUT_INSTALLER" != "pip" ] && [ "$INPUT_INSTALLER" != "uv" ]; then
+    echo "::error::Unknown installer '$INPUT_INSTALLER', supported values: pip, uv"
+    exit 1
+fi
+
+pkg_install() {
+    if [ "$INPUT_INSTALLER" == "uv" ]; then
+        # --system: install into the interpreter provided by setup-python,
+        # no virtual environment required.
+        uv pip install --system "$@"
+    else
+        pip3 install "$@"
+    fi
+}
+
 # The actions doesn't depends on any images,
 # so we have to try various package manager.
 echo ::group:: Installing Sphinx
 
-echo Installing sphinx via pip
+echo Installing sphinx via $INPUT_INSTALLER
 if [ -z "$INPUT_SPHINX_VERSION" ] ; then
-    pip3 install -U sphinx
+    pkg_install -U sphinx
 else
-    pip3 install -U sphinx==$INPUT_SPHINX_VERSION
+    pkg_install -U sphinx==$INPUT_SPHINX_VERSION
 fi
 
 echo Adding ~/.local/bin to system path
@@ -37,14 +52,14 @@ else
     echo Everything goes well
 fi
 
-pip3 install -U sphinxnotes-incrbuild>=1.0
+pkg_install -U 'sphinxnotes-incrbuild>=1.0'
 
 echo ::endgroup::
 
 if [ ! -z "$INPUT_REQUIREMENTS_PATH" ] ; then
     echo ::group:: Installing dependencies declared by $INPUT_REQUIREMENTS_PATH
     if [ -f "$INPUT_REQUIREMENTS_PATH" ]; then
-        pip3 install -r "$INPUT_REQUIREMENTS_PATH"
+        pkg_install -r "$INPUT_REQUIREMENTS_PATH"
     else
         echo No $INPUT_REQUIREMENTS_PATH found, skipped
     fi
@@ -54,7 +69,7 @@ fi
 if [ ! -z "$INPUT_PYPROJECT_EXTRAS" ] ; then
     echo ::group:: Installing dependencies declared by pyproject.toml[$INPUT_PYPROJECT_EXTRAS]
     if [ -f "pyproject.toml" ]; then
-        pip3 install .[$INPUT_PYPROJECT_EXTRAS]
+        pkg_install .[$INPUT_PYPROJECT_EXTRAS]
     else
         echo No pyproject.toml found, skipped
     fi
@@ -64,8 +79,10 @@ fi
 if [ ! -z "$INPUT_PYPROJECT_GROUP" ] ; then
     echo ::group:: Installing dependency group declared by pyproject.toml[$INPUT_PYPROJECT_GROUP]
     if [ -f "pyproject.toml" ]; then
-        pip3 install -U 'pip>=25.1'  # --group requires pip 25.1+
-        pip3 install --group "pyproject.toml:$INPUT_PYPROJECT_GROUP"
+        if [ "$INPUT_INSTALLER" == "pip" ]; then
+            pip3 install -U 'pip>=25.1'  # --group requires pip 25.1+
+        fi
+        pkg_install --group "pyproject.toml:$INPUT_PYPROJECT_GROUP"
     else
         echo No pyproject.toml found, skipped
     fi


### PR DESCRIPTION
Closes #43, supersedes #58.

On #58, @SilverRainZ asked for this to be *"optional and fully tested"* — this PR is built around exactly that:

**Optional:** a new `installer` input, default `pip`. Nothing changes for existing users; `installer: uv` is pure opt-in, and unknown values fail fast with a clear error.

**Fully tested:** a new `test.yml` workflow builds this repository's own docs through the local action (`publish: false`) across the full matrix of `installer` (pip, uv) × `cache` (false, true), and asserts HTML output exists. It runs on every future PR, so the repo gains regression CI beyond this feature. Green run on my fork: https://github.com/arunoruto/sphinx-pages/actions/runs/30932486228 (uv jobs: 16–17s, pip jobs: 20–23s — even on this small docs project).

## How it differs from #58

- **No virtual environment.** Instead of `uv venv` + `source activate`, all uv installs use `uv pip install --system`, targeting the same setup-python interpreter that pip uses. This eliminates the venv/cache interaction concern raised in #58 — the `cache` input works identically for both installers (covered by the test matrix).
- **Covers the PEP 735 `pyproject_group` path** added in #60: uv supports `--group pyproject.toml:NAME` natively, so the pip ≥ 25.1 self-upgrade is skipped on the uv path.
- **uv is provisioned by the official [astral-sh/setup-uv](https://github.com/astral-sh/setup-uv) action** (pinned to `v9.0.0`; setup-uv no longer publishes major tags), with its cache tied to the existing `cache` input. When `installer: uv`, the pointless pip cache in setup-python is skipped.
- All `pip3 install` call sites route through one small `pkg_install()` wrapper in `main.sh`, so future install paths automatically support both installers. As a drive-by, `sphinxnotes-incrbuild>=1.0` is now quoted — previously the unquoted `>=` was parsed as a shell redirection.

README documents the new input and a short "Speed up installation with uv" tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)